### PR TITLE
Fix rc failing grommet flow types

### DIFF
--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -11,8 +11,7 @@ import {
   DashboardUserForm,
   DashboardUsersPage,
   DashboardPressReleasesPage,
-  DashboardPressReleasePage,
-  ExampleApp
+  DashboardPressReleasePage
 } from './containers';
 
 export const getRoutes = (store) => {


### PR DESCRIPTION
Fix

Remove broken flow types for grommet
- Add a generic react node type
- Delete failing types