### PR TITLE
Feat: add grommet-cms alias and refactor to import from the alias

### DIFF
--- a/grommet-toolbox.config.js
+++ b/grommet-toolbox.config.js
@@ -39,7 +39,10 @@ export default {
       root: [
         path.resolve(__dirname, './node_modules'),
         path.resolve(__dirname, './src')
-      ]
+      ],
+      alias: {
+        'grommet-cms': path.resolve(__dirname, './src/js/')
+      }
     },
     module: {
       preLoaders: [{

--- a/src/js/components/Dashboard/AssetTile.js
+++ b/src/js/components/Dashboard/AssetTile.js
@@ -6,13 +6,13 @@ import Menu from 'grommet/components/Menu';
 import TrashIcon from 'grommet/components/icons/base/Trash';
 import EditIcon from 'grommet/components/icons/base/Edit';
 import DocumentIcon from 'grommet/components/icons/base/Document';
-import { isImage } from '../../utils';
+import { isImage } from 'grommet-cms/utils';
 
 export default function AssetTile ({ id, path, title, onDeleteClick }) {
   const thumbnail = (isImage(path))
     ? <Box 
-        texture={path} 
-        size={{ 
+        texture={path}
+        size={{
           height: { min: 'small', max: 'small' },
           width: { min: 'medium', max: 'medium' }
         }}
@@ -21,8 +21,8 @@ export default function AssetTile ({ id, path, title, onDeleteClick }) {
         }}
         colorIndex="grey-3"
       />
-    : <Box 
-        size={{ 
+    : <Box
+        size={{
           height: { min: 'small', max: 'small' },
           width: { min: 'medium', max: 'medium' }
         }}

--- a/src/js/containers/App/index.js
+++ b/src/js/containers/App/index.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import GrommetApp from 'grommet/components/App';
 import Helmet from 'react-helmet';
-import Nav from '../../components/Nav';
+import Nav from 'grommet-cms/components/Nav';
 
 class App extends React.Component {
   render() {

--- a/src/js/containers/Assets/AssetPage.js
+++ b/src/js/containers/Assets/AssetPage.js
@@ -10,7 +10,7 @@ import FormFields from 'grommet/components/FormFields';
 import FormField from 'grommet/components/FormField';
 import TrashIcon from 'grommet/components/icons/base/Trash';
 import DocumentIcon from 'grommet/components/icons/base/Document';
-import { isImage } from '../../utils';
+import { isImage } from 'grommet-cms/utils';
 
 export class AssetPage extends Component {
   constructor(props) {
@@ -47,7 +47,7 @@ export class AssetPage extends Component {
     if (event.target instanceof HTMLInputElement) {
       const key = event.target.id;
       const val = (event.target.files)
-        ? event.target.files[0] 
+        ? event.target.files[0]
         : event.target.value;
       let obj = {};
       obj[key] = val;
@@ -78,14 +78,14 @@ export class AssetPage extends Component {
       ? <Box pad="medium">
           <Image src={path} size="medium" />
           <Box pad={{ vertical: 'small' }}>
-            <Anchor label="Remove Image" icon={<TrashIcon />} 
+            <Anchor label="Remove Image" icon={<TrashIcon />}
               onClick={this._removeAssetClick} />
           </Box>
         </Box>
       : <Box pad="medium">
           <DocumentIcon size="xlarge" />
           <Box pad={{ vertical: 'small' }}>
-            <Anchor label="Remove File" icon={<TrashIcon />} 
+            <Anchor label="Remove File" icon={<TrashIcon />}
               onClick={this._removeAssetClick} />
           </Box>
         </Box>;

--- a/src/js/containers/Assets/AssetsPage.js
+++ b/src/js/containers/Assets/AssetsPage.js
@@ -5,7 +5,7 @@ import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
 import Heading from 'grommet/components/Heading';
 import SpinningIcon from 'grommet/components/icons/Spinning';
-import { AssetTile } from '../../components/Dashboard';
+import { AssetTile } from 'grommet-cms/components/Dashboard';
 
 export class AssetsPage extends Component {
   componentWillMount() {
@@ -18,7 +18,7 @@ export class AssetsPage extends Component {
 
   _renderLoader(request) {
     return (request)
-      ? <SpinningIcon /> 
+      ? <SpinningIcon />
       : <Box pad="medium">
           <Heading tag="h2">
             Click 'Add Asset' to add your first asset.
@@ -29,12 +29,12 @@ export class AssetsPage extends Component {
   render() {
     const { post: assets, request } = this.props;
     const assetBlocks = (assets.length > 0 && !request)
-      ? assets.map(({_id, title, path}) => 
-        <AssetTile 
-          key={`asset-${_id}`} 
+      ? assets.map(({_id, title, path}) =>
+        <AssetTile
+          key={`asset-${_id}`}
           id={_id}
           onDeleteClick={this._onDeleteClick.bind(this, _id)}
-          title={title} 
+          title={title}
           path={path} />)
       : this._renderLoader(request);
 

--- a/src/js/containers/ContentBlocks/index.js
+++ b/src/js/containers/ContentBlocks/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import Box from 'grommet/components/Box';
-import { BLOCK_TYPE_MAP } from '../Dashboard/DashboardContentBlocks/constants';
+import { BLOCK_TYPE_MAP } from 'grommet-cms/containers/Dashboard/DashboardContentBlocks/constants';
 
 export default class ContentBlocks extends Component {
   _renderBlocks(blocks) {

--- a/src/js/containers/Dashboard/DashboardBlockForm/CarouselForm.js
+++ b/src/js/containers/Dashboard/DashboardBlockForm/CarouselForm.js
@@ -6,7 +6,7 @@ import Tab from 'grommet/components/Tab';
 import AddIcon from 'grommet/components/icons/base/Add';
 import TrashIcon from 'grommet/components/icons/base/Trash';
 import CarouselSlideForm from './CarouselSlideForm';
-import ConfirmLayer from '../../../components/Dashboard/ConfirmLayer';
+import { ConfirmLayer } from 'grommet-cms/components/Dashboard';
 
 export class CarouselForm extends Component {
   constructor(props) {

--- a/src/js/containers/Dashboard/DashboardContainer/index.js
+++ b/src/js/containers/Dashboard/DashboardContainer/index.js
@@ -1,12 +1,13 @@
 import React, { Component, PropTypes } from 'react';
 
 import { connect } from 'react-redux';
-import { logout } from '../../LoginPage/actions';
+import { logout } from 'grommet-cms/containers/LoginPage/actions';
 import Helmet from 'react-helmet';
-
 import GrommetApp from 'grommet/components/App';
-import DashboardNav from '../../../components/Dashboard/Nav';
-import DashboardError from '../../../components/Dashboard/Error';
+import {
+  Nav as DashboardNav,
+  Error as DashboardError
+} from 'grommet-cms/components/Dashboard/Nav';
 
 export class Dashboard extends Component {
   constructor(props) {

--- a/src/js/containers/Dashboard/DashboardContentBlock/index.js
+++ b/src/js/containers/Dashboard/DashboardContentBlock/index.js
@@ -5,8 +5,7 @@ import {
 } from '../DashboardContentBlocks/actions';
 import { connect } from 'react-redux';
 import Box from 'grommet/components/Box';
-import PreviewHeader from '../../../components/ContentBlocks/PreviewHeader';
-import BlockSelector from '../../../components/ContentBlocks/BlockSelector';
+import { PreviewHeader, BlockSelector } from 'grommet-cms/components/ContentBlocks';
 import { BLOCK_TYPE_MAP } from '../DashboardContentBlocks/constants';
 
 export class DashboardContentBlock extends Component {

--- a/src/js/containers/Dashboard/DashboardContentBlocks/constants.js
+++ b/src/js/containers/Dashboard/DashboardContentBlocks/constants.js
@@ -2,30 +2,32 @@ import React from 'react';
 import Box from 'grommet/components/Box';
 import PlayFillIcon from 'grommet/components/icons/base/PlayFill';
 
-import BlockParagraphPreview from '../../../components/ContentBlocks/BlockParagraphPreview';
-import BlockHeadingPreview from '../../../components/ContentBlocks/BlockHeadingPreview';
-import BlockImagePreview from '../../../components/ContentBlocks/BlockImagePreview';
-import BlockCardPreview from '../../../components/ContentBlocks/BlockCardPreview';
-import BlockQuotePreview from '../../../components/ContentBlocks/BlockQuotePreview';
-import BlockVideoPreview from '../../../components/ContentBlocks/BlockVideoPreview';
-import BlockCarouselPreview from '../../../components/ContentBlocks/BlockCarouselPreview';
-
-import ImageForm from '../DashboardBlockForm/ImageForm';
-import ParagraphForm from '../DashboardBlockForm/ParagraphForm';
-import ImageParagraphForm from '../DashboardBlockForm/ImageParagraphForm';
-import CardParagraphForm from '../DashboardBlockForm/CardParagraphForm';
-import QuoteForm from '../DashboardBlockForm/QuoteForm';
-import VideoForm from '../DashboardBlockForm/VideoForm';
-import CarouselForm from '../DashboardBlockForm/CarouselForm';
-
-import BlockHeading from '../../../components/ContentBlocks/BlockHeading';
-import BlockParagraph from '../../../components/ContentBlocks/BlockParagraph';
-import BlockImage from '../../../components/ContentBlocks/BlockImage';
-import BlockImageParagraph from '../../../components/ContentBlocks/BlockImageParagraph';
-import BlockCard from '../../../components/ContentBlocks/BlockCard';
-import BlockQuote from '../../../components/ContentBlocks/BlockQuote';
-import BlockVideo from '../../../components/ContentBlocks/BlockVideo';
-import BlockCarousel from '../../../components/ContentBlocks/BlockCarousel';
+import {
+  BlockParagraphPreview,
+  BlockHeadingPreview,
+  BlockImagePreview,
+  BlockCardPreview,
+  BlockQuotePreview,
+  BlockVideoPreview,
+  BlockCarouselPreview,
+  BlockHeading,
+  BlockParagraph,
+  BlockImage,
+  BlockImageParagraph,
+  BlockCard,
+  BlockQuote,
+  BlockVideo,
+  BlockCarousel
+} from 'grommet-cms/components/ContentBlocks';
+import {
+  ImageForm,
+  ParagraphForm,
+  ImageParagraphForm,
+  CardParagraphForm,
+  QuoteForm,
+  VideoForm,
+  CarouselForm
+} from 'grommet-cms/containers/Dashboard/DashboardBlockForm';
 
 export const BLOCK_TYPE_MAP = {
   BlockParagraph: {

--- a/src/js/containers/Dashboard/DashboardFileUpload/index.js
+++ b/src/js/containers/Dashboard/DashboardFileUpload/index.js
@@ -5,7 +5,7 @@ import { fileInsert, fileUpload, fileError } from './actions';
 
 import Button from 'grommet/components/Button';
 import Image from 'grommet/components/icons/base/Image';
-import FileInsertLayer from '../../../components/Dashboard/FileInsertLayer';
+import FileInsertLayer from 'grommet-cms/components/Dashboard/FileInsertLayer';
 
 export class DashboardFileUpload extends Component {
   constructor(props) {

--- a/src/js/containers/Dashboard/DashboardPressReleasePage/form.js
+++ b/src/js/containers/Dashboard/DashboardPressReleasePage/form.js
@@ -10,7 +10,7 @@ import Heading from 'grommet/components/Heading';
 import Select from 'grommet/components/Select';
 import FileUpload from '../DashboardFileUpload';
 import DashboardContentBlocks from '../DashboardContentBlocks';
-import { formatDate } from '../../../utils';
+import { formatDate } from 'grommet-cms/utils';
 
 export class PressReleaseForm extends Component {
   constructor(props) {

--- a/src/js/containers/Dashboard/DashboardPressReleasesPage/index.js
+++ b/src/js/containers/Dashboard/DashboardPressReleasesPage/index.js
@@ -2,14 +2,14 @@ import React, { Component, PropTypes } from 'react';
 
 import { connect } from 'react-redux';
 import { getPressReleases, deletePressRelease } from './actions';
-import { blockAddList } from '../DashboardContentBlocks/actions';
+import { blockAddList } from 'grommet-cms/containers/Dashboard/DashboardContentBlocks/actions';
 import { browserHistory } from 'react-router';
 
-import List from '../../../components/Dashboard/List';
+import List from 'grommet-cms/components/Dashboard/List';
 import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
 import Heading from 'grommet/components/Heading';
-import ConfirmLayer from '../../../components/Dashboard/ConfirmLayer';
+import ConfirmLayer from 'grommet-cms/components/Dashboard/ConfirmLayer';
 import Add from 'grommet/components/icons/base/Add';
 
 export class DashboardPressReleasesPage extends Component {

--- a/src/js/containers/Dashboard/DashboardUserForm/index.js
+++ b/src/js/containers/Dashboard/DashboardUserForm/index.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { createUser, userRequestError } from './actions';
 
 import Box from 'grommet/components/Box';
-import UserForm from '../../../components/Dashboard/UserForm';
+import UserForm from 'grommet-cms/components/Dashboard/UserForm';
 
 export class DashboardUserForm extends Component {
   constructor(props) {

--- a/src/js/containers/Dashboard/DashboardUsersPage/index.js
+++ b/src/js/containers/Dashboard/DashboardUsersPage/index.js
@@ -4,10 +4,10 @@ import { connect } from 'react-redux';
 import { getUsers, deleteUser } from './actions';
 import { browserHistory } from 'react-router';
 
-import DashboardList from '../../../components/Dashboard/List';
+import DashboardList from 'grommet-cms/components/Dashboard/List';
 import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
-import ConfirmLayer from '../../../components/Dashboard/ConfirmLayer';
+import ConfirmLayer from 'grommet-cms/components/Dashboard/ConfirmLayer';
 import Add from 'grommet/components/icons/base/Add';
 
 export class DashboardUsersPage extends Component {

--- a/src/js/containers/EntryOrder/index.js
+++ b/src/js/containers/EntryOrder/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 
 import Layer from 'grommet/components/Layer';
-import EntryOrderList from '../../components/Dashboard/EntryOrderList';
+import EntryOrderList from 'grommet-cms/components/Dashboard/EntryOrderList';
 
 export class EntryOrder extends Component {
   constructor(props) {

--- a/src/js/containers/LoginPage/index.js
+++ b/src/js/containers/LoginPage/index.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { login } from './actions';
 
 import Box from 'grommet/components/Box';
-import UserForm from '../../components/Dashboard/UserForm';
+import UserForm from 'grommet-cms/components/Dashboard/UserForm';
 
 export class LoginPage extends Component {
   constructor(props) {

--- a/src/js/containers/PressReleasePage/index.js
+++ b/src/js/containers/PressReleasePage/index.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Helmet from 'react-helmet';
-import { getPressRelease } from '../Dashboard/DashboardPressReleasePage/actions';
-import ContentBlocks from '../ContentBlocks';
+import { getPressRelease } from 'grommet-cms/containers/Dashboard/DashboardPressReleasePage/actions';
+import ContentBlocks from 'grommet-cms/containers/ContentBlocks';
 import Box from 'grommet/components/Box';
 import Headline from 'grommet/components/Headline';
 

--- a/src/js/reducers/index.js
+++ b/src/js/reducers/index.js
@@ -1,11 +1,11 @@
 import { routerReducer as routing } from 'react-router-redux';
 import { combineReducers } from 'redux';
 
-import api from '../containers/Api/reducer';
-import homepage from '../containers/HomePage/reducer';
-import login from '../containers/LoginPage/reducer';
-import assets from '../containers/Assets/reducer';
-import * as dashboardReducers from '../containers/Dashboard/reducers';
+import api from 'grommet-cms/containers/Api/reducer';
+import homepage from 'grommet-cms/containers/HomePage/reducer';
+import login from 'grommet-cms/containers/LoginPage/reducer';
+import assets from 'grommet-cms/containers/Assets/reducer';
+import * as dashboardReducers from 'grommet-cms/containers/Dashboard/reducers';
 
 const rootReducer = combineReducers({
   api,


### PR DESCRIPTION
-  This will allow us to bootstrap the npm module for grommet-cms and hopefully will make the cms more modular by relieving dependency sharing

@karatechops please let me know if there are any issues with this.  I hope this will help, but there is a lot changing all at once so I want to make sure that I got it right.  Thank you!